### PR TITLE
Markup fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To run these code samples you will need Java 1.7 or higher and RabbitMQ (3.5.4).
 
 Be sure to go into common.AMQPCommon.java and update the connection info for RabbitMQ: (you can get this info from the RabbitMQ logs or doing a "docker ps" if you are using the docker image)
 
+```
 public static Channel connect() throws Exception {	
 	ConnectionFactory factory = new ConnectionFactory();	
 
@@ -18,6 +19,7 @@ public static Channel connect() throws Exception {
 	Connection conn = factory.newConnection();	
 	return conn.createChannel();	
 }
+```
 
 You will also need to be sure and run the AMQPInitialize class to setup all of the exchanges, queues, and bindings used by these examples.
 


### PR DESCRIPTION
This makes the whole code example render in a monospace font.